### PR TITLE
Formatting for output explorer

### DIFF
--- a/lib/create_report.py
+++ b/lib/create_report.py
@@ -1,7 +1,6 @@
 import os
 import pandas as pd
 from IPython.display import display, Markdown
-from IPython.core.display import SVG
 from collections import OrderedDict
 from operator import itemgetter
 
@@ -55,8 +54,9 @@ def find_and_sort_filenames(foldername, *,
                             by_demographics_or_population="demographics", 
                             population_subset="80+",
                             demographics_subset=[],
-                            pre_string="by ", tail_string=".svg",
-                            files_to_exclude=["Cumulative vaccination figures.svg"]):
+                            file_extension="csv",
+                            pre_string="by ", tail_string=None,
+                            files_to_exclude=None):
     '''
     List files from specified folder ("figures" or "tables") and sort in predetermined order
     
@@ -68,6 +68,7 @@ def find_and_sort_filenames(foldername, *,
     population_subset (str): population group to include
     demographics_subset (list): list of strings to filter filenames to a subset of demographic features
                                 (e.g. ["ethnicity_6_groups", "imd_categories"])
+    file_extension (str): extension of the files to list (use to pick out either SVGs or PNGs)
     pre_string: string found in filename AHEAD OF desired factor for sorting (e.g. for filename containing "by ageband" use "by ").
                 filename will be split at this point.
     tail_string: string found in filename AFTER desired factor for sorting (e.g. for filename containing "by ageband.csv" use ".csv").
@@ -75,6 +76,9 @@ def find_and_sort_filenames(foldername, *,
     files_to_exclude (list): any files in target folder not to be included
     
     '''
+    tail_string = tail_string or f".{file_extension}"
+    files_to_exclude = files_to_exclude or [f"Cumulative vaccination figures.{file_extension}"]
+
     savepath = get_savepath(subfolder=org_breakdown)
     
     if subfolder:  
@@ -85,7 +89,10 @@ def find_and_sort_filenames(foldername, *,
     for f in files_to_exclude:
         if f in file_list:
             file_list.remove(f)
-    
+
+    # restrict to files with the specified extension
+    file_list = [f for f in file_list if f.endswith(f".{file_extension}")]
+
     # restrict to population subset of interest based on string supplied
     file_list = [f for f in file_list if population_subset in f]
 
@@ -141,13 +148,13 @@ def find_and_sort_filenames(foldername, *,
     return(out_list.keys())
 
 
-
-def show_chart(filepath, *, org_breakdown="", subfolder="", title="on"):
+def show_chart(filepath, image_format, org_breakdown="", subfolder="", title="on"):
     '''
     Show chart from specified filepath. Rename filepaths for use as chart titles.
     
     Inputs:
     filepath (str):  file path
+    image_format (ImageFormat): the type of image to show
     org_breakdown (str): Type of org breakdown (e.g "stp")
     subfolder (str): subfolder of in which to find files (e.g. an individual STP)
     title (str): "on" or "off"
@@ -166,15 +173,13 @@ def show_chart(filepath, *, org_breakdown="", subfolder="", title="on"):
         title_string = filepath
         for v in variable_renaming: # replace short strings with full variable names
             title_string = title_string.replace(v, f"{variable_renaming[v]}")
-        title_string = title_string.replace(" by","\n ### by").replace(".svg","")
+        title_string = title_string.replace(" by","\n ### by").replace(f".{image_format.extension}", "")
         display(Markdown(f"### {title_string}"))
         if (len(subfolder)>0) & (~any(s in filepath for s in ["overall","sex","imd_categories"])):
             display(Markdown(f"Zero percentages may represent suppressed low numbers; raw numbers were rounded to nearest 7"))
            
-    
-    display(SVG(filename=imgpath))
-    
-    
+    display(image_format.formatter(filename=imgpath))
+
 
 def show_table(filename, latest_date_fmt, *, org_breakdown=None, show_carehomes=False, 
                rows_to_exclude = [],

--- a/lib/image_formats.py
+++ b/lib/image_formats.py
@@ -1,0 +1,20 @@
+import collections
+import os
+
+from IPython.display import Image
+from IPython.core.display import SVG
+
+
+ImageFormat = collections.namedtuple("ImageFormat", ["extension", "formatter"])
+
+
+def pick_image_format():
+    try:
+        fmt = os.environ["IMAGE_FORMAT"]
+    except KeyError:
+        raise Exception("You must set the IMAGE_FORMAT environment variable to svg or png")
+
+    if fmt == "svg":
+        return ImageFormat("svg", SVG)
+    if fmt == "png":
+        return ImageFormat("png", Image)

--- a/lib/report_results.py
+++ b/lib/report_results.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 import os
 
 from datetime import datetime
-import json
 from IPython.display import display, Markdown
 
 
@@ -236,12 +235,12 @@ def filtered_cumulative_sum(df, columns, latest_date, reference_column_name="cov
 
 def make_vaccine_graphs(df, latest_date, savepath, savepath_figure_csvs, vaccine_type="first_dose", suffix=""):
     '''
-    Cumulative chart by day of total vaccines given across key eligible groups
+    Cumulative chart by day of total vaccines given across key eligible groups. Produces both SVG and PNG versions.
     
     Args:
         df (dataframe): cumulative daily data on vaccines given per group
         latest_date (str): latest date across dataset in YYYY-MM-DD format
-        savepath (dict): path to save figure as svg (savepath["figures"])
+        savepath (dict): path to save figure (savepath["figures"])
         savepath_figure_csvs (str): path to save machine readable csv for recreating the chart
         vaccine_type (str): used in output strings to describe type of vaccine received e.g. "first_dose", "moderna". 
                             Also appended to filename of output. 
@@ -296,10 +295,12 @@ def make_vaccine_graphs(df, latest_date, savepath, savepath_figure_csvs, vaccine
     plt.legend(bbox_to_anchor=(1.04,1), loc="upper left")
     
     # export figure to file and display it
-    plt.savefig(os.path.join(savepath["figures"], f"{title}.svg"), dpi=300, bbox_inches='tight')
+    filename = os.path.join(savepath["figures"], title)
+    plt.savefig(f"{filename}.svg", dpi=300, bbox_inches='tight')
+    plt.savefig(f"{filename}.png", dpi=300, bbox_inches='tight')
     plt.show()
     
-    
+
     
 def report_results(df_dict_cum, group, latest_date, breakdown=None):
     '''
@@ -563,7 +564,7 @@ def create_detailed_summary_uptake(summarised_data_dict,  formatted_latest_date,
 def plot_dem_charts(summary_stats_results, cumulative_data_dict, formatted_latest_date, savepath, pop_subgroups=["80+", "70-79"], groups_dict=None, groups_to_exclude=None, savepath_figure_csvs=None, include_overall=False, org_name="", suffix=""):
     
     '''
-    Plot vaccine coverage charts by demographic features
+    Plot vaccine coverage charts by demographic features. Produces both SVG and PNG versions.
     
     Args:
         summary_stats_results (dict): summary statistics for full cohort to use for plotting comparator lines
@@ -657,6 +658,8 @@ def plot_dem_charts(summary_stats_results, cumulative_data_dict, formatted_lates
                 figure_savepath = savepath["figures"][org_name]          
             else: 
                 figure_savepath = savepath["figures"]
-            plt.savefig(os.path.join(figure_savepath, f"{vaccine_type}COVID vaccinations among {k} population by {c.replace('_',' ')}.svg"), dpi=300, bbox_inches='tight')
+            filename = os.path.join(figure_savepath, f"{vaccine_type}COVID vaccinations among {k} population by {c.replace('_', ' ')}")
+            plt.savefig(f"{filename}.svg", dpi=300, bbox_inches='tight')
+            plt.savefig(f"{filename}.png", dpi=300, bbox_inches='tight')
 
             plt.show() 

--- a/project.yaml
+++ b/project.yaml
@@ -24,7 +24,7 @@ actions:
         text: interim-outputs/text/*
 
   generate_report:
-    run: jupyter:latest jupyter nbconvert /workspace/notebooks/opensafely_vaccine_report_overall.ipynb --execute --to html --output-dir=/workspace/output --ExecutePreprocessor.timeout=86400 --no-input
+    run: jupyter:latest env IMAGE_FORMAT=svg jupyter nbconvert /workspace/notebooks/opensafely_vaccine_report_overall.ipynb --execute --to html --output-dir=/workspace/output --ExecutePreprocessor.timeout=86400 --no-input
 
     needs: [generate_delivery_cohort, generate_notebook]
     outputs:
@@ -33,7 +33,7 @@ actions:
         csvs: machine_readable_outputs/table_csvs/*
 
   generate_simple_report:
-    run: jupyter:latest jupyter nbconvert /workspace/notebooks/opensafely_vaccine_report_overall.ipynb --execute --to html --template basic --output=/workspace/output/opensafely_vaccine_report_overall_simple.html --ExecutePreprocessor.timeout=86400 --no-input
+    run: jupyter:latest env IMAGE_FORMAT=png jupyter nbconvert /workspace/notebooks/opensafely_vaccine_report_overall.ipynb --execute --to html --template basic --output=/workspace/output/opensafely_vaccine_report_overall_simple.html --ExecutePreprocessor.timeout=86400 --no-input
 
     needs: [generate_delivery_cohort, generate_notebook]
     outputs:

--- a/project.yaml
+++ b/project.yaml
@@ -2,7 +2,7 @@ version: '3.0'
 
 expectations:
   population_size: 10000
-   
+
 actions:
 
   generate_delivery_cohort:
@@ -17,17 +17,25 @@ actions:
     needs: [generate_delivery_cohort]
     outputs:
       moderately_sensitive:
-        notebook: output/population_characteristics.html 
+        notebook: output/population_characteristics.html
         figures: interim-outputs/figures/*
         tables: interim-outputs/tables/*
         csvs: machine_readable_outputs/*/* # two possible subfolders
         text: interim-outputs/text/*
-        
+
   generate_report:
     run: jupyter:latest jupyter nbconvert /workspace/notebooks/opensafely_vaccine_report_overall.ipynb --execute --to html --output-dir=/workspace/output --ExecutePreprocessor.timeout=86400 --no-input
 
     needs: [generate_delivery_cohort, generate_notebook]
     outputs:
       moderately_sensitive:
-        notebook: output/opensafely_vaccine_report_overall.html 
+        notebook: output/opensafely_vaccine_report_overall.html
         csvs: machine_readable_outputs/table_csvs/*
+
+  generate_simple_report:
+    run: jupyter:latest jupyter nbconvert /workspace/notebooks/opensafely_vaccine_report_overall.ipynb --execute --to html --template basic --output=/workspace/output/opensafely_vaccine_report_overall_simple.html --ExecutePreprocessor.timeout=86400 --no-input
+
+    needs: [generate_delivery_cohort, generate_notebook]
+    outputs:
+      moderately_sensitive:
+        notebook: output/opensafely_vaccine_report_overall_simple.html


### PR DESCRIPTION
There are [before](https://github.com/opensafely/output-explorer-test-repo/blob/master/test-outputs/vaccine-coverage-original.html) and [after](https://github.com/opensafely/output-explorer-test-repo/blob/master/test-outputs/vaccine-coverage-new.html) versions of the output available.