### PR TITLE
Adding an announcement RE reports no longer being updated

### DIFF
--- a/released-outputs/booster-third-doses.html
+++ b/released-outputs/booster-third-doses.html
@@ -9,9 +9,12 @@
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>OpenSAFELY is a new secure analytics platform for electronic patient records built on behalf of NHS England to deliver urgent academic and operational research during the pandemic.</p>
-<p>This is an extension of our <a href="https://reports.opensafely.org/reports/vaccine-coverage/">regular weekly report</a> on COVID-19 vaccination coverage in England using data from 40% of general practices that use TPP electronic health record software. <strong>The data requires careful interpretation and there are a number of caveats. Please read the full detail about our methods and discussion of our earlier results (as of 17 March 2021) in our <a href="https://doi.org/10.3399/BJGP.2021.0376">peer-reviewed publication in the British Journal of General Practice</a>.</strong></p>
+<p>This is an extension of our <a href="https://reports.opensafely.org/reports/vaccine-coverage/">most recent weekly report</a> on COVID-19 vaccination coverage in England using data from 40% of general practices that use TPP electronic health record software. <strong>The data requires careful interpretation and there are a number of caveats. Please read the full detail about our methods and discussion of our earlier results (as of 17 March 2021) in our <a href="https://doi.org/10.3399/BJGP.2021.0376">peer-reviewed publication in the British Journal of General Practice</a>.</strong></p>
 <p>The full analytical methods behind the latest results in this report are available <a href="https://github.com/opensafely/nhs-covid-vaccination-uptake">here</a>.</p>
-<p><strong>Update: Our vaccine reports are currently published monthly.  If you rely on more regular data updates for your own reporting or analysis please contact team@opensafely.org to let us know.</strong></p>
+
+<p><strong>Update: Our vaccine reports are no longer being updated. If you rely on more regular data updates for your
+    own reporting or analysis please contact team@opensafely.org to let us know.</strong></p>
+
 
 </div>
 </div>

--- a/released-outputs/second_doses.html
+++ b/released-outputs/second_doses.html
@@ -9,9 +9,12 @@
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>OpenSAFELY is a new secure analytics platform for electronic patient records built on behalf of NHS England to deliver urgent academic and operational research during the pandemic.</p>
-<p>This is an extension of our <a href="https://reports.opensafely.org/reports/vaccine-coverage/">regular weekly report</a> on COVID-19 vaccination coverage in England using data from 40% of general practices that use TPP electronic health record software. <strong>The data requires careful interpretation and there are a number of caveats. Please read the full detail about our methods and discussion of our earlier results (as of 17 March 2021) in our <a href="https://doi.org/10.3399/BJGP.2021.0376">peer-reviewed publication in the British Journal of General Practice</a>.</strong></p>
+<p>This is an extension of our <a href="https://reports.opensafely.org/reports/vaccine-coverage/">most recent weekly report</a> on COVID-19 vaccination coverage in England using data from 40% of general practices that use TPP electronic health record software. <strong>The data requires careful interpretation and there are a number of caveats. Please read the full detail about our methods and discussion of our earlier results (as of 17 March 2021) in our <a href="https://doi.org/10.3399/BJGP.2021.0376">peer-reviewed publication in the British Journal of General Practice</a>.</strong></p>
 <p>The full analytical methods behind the latest results in this report are available <a href="https://github.com/opensafely/nhs-covid-vaccination-uptake">here</a>.</p>
-<p><strong>Update: Our vaccine reports are currently published monthly.  If you rely on more regular data updates for your own reporting or analysis please contact team@opensafely.org to let us know.</strong></p>
+
+<p><strong>Update: Our vaccine reports are no longer being updated. If you rely on more regular data updates for your
+    own reporting or analysis please contact team@opensafely.org to let us know.</strong></p>
+
 
 </div>
 </div>


### PR DESCRIPTION
Preamble text has been updated to reflect the fact that we are no longer regularly updating our vaccine reports.

This includes the addition of the following text:

> Update: Our vaccine reports are no longer being updated. If you rely on more regular data updates for your own reporting or analysis please contact team@opensafely.org to let us know.

And referring to the first report as our 'most recent' report, rather than our 'regular weekly'.